### PR TITLE
Add --version flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,11 @@ use std::process;
 fn main() {
     let arg = env::args().nth(1);
 
+    if arg.as_deref() == Some("--version") {
+        println!("ndir {}", env!("CARGO_PKG_VERSION"));
+        return;
+    }
+
     if arg.as_deref() == Some("--init") {
         print!("{}", include_str!("../shell/ndir.zsh"));
         return;


### PR DESCRIPTION
## Summary

- Add `--version` flag that prints `ndir <version>` using `CARGO_PKG_VERSION`

closes #1

## Test plan

- [x] `cargo build && ./target/debug/ndir --version` prints `ndir 0.4.2`
- [x] `cargo clippy` passes
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)