### PR TITLE
Add --locked flag to cargo publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,6 @@ jobs:
             exit 1
           }
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish
+      - run: cargo publish --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `--locked` flag to `cargo publish` to ensure Cargo.lock consistency during publish
- Catches Cargo.lock update misses early (like the one we hit in v0.4.1)

## Test plan

- [x] No code changes, workflow-only update

🤖 Generated with [Claude Code](https://claude.com/claude-code)