### PR TITLE
Simplify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,16 +43,12 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
-      - name: Create or update GitHub Release
+      - name: Create GitHub Release
         run: |
-          if gh release view ${{ github.ref_name }} > /dev/null 2>&1; then
-            gh release upload ${{ github.ref_name }} ndir-*.tar.gz --clobber
-          else
-            gh release create ${{ github.ref_name }} \
-              --title "${{ github.ref_name }}" \
-              --generate-notes \
-              ndir-*.tar.gz
-          fi
+          gh release create ${{ github.ref_name }} \
+            --title "${{ github.ref_name }}" \
+            --generate-notes \
+            ndir-*.tar.gz
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Remove unnecessary existing-release check from release workflow
- Tag retags should not happen; if something goes wrong, release a new patch version instead

## Test plan

- [x] Workflow-only change, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)